### PR TITLE
Fix story search in search_controller

### DIFF
--- a/lib/controllers/search_controller.dart
+++ b/lib/controllers/search_controller.dart
@@ -145,27 +145,27 @@ class SearchController extends GetxController {
         _logger.info('page: $page');
         _logger.info('maxPage: $maxPage');
         return;
-      } else {
-        if (searchTerm.isEmpty || searchTerm.length < 3) {
-          return;
-        }
-        SearchResult result = await api.beginSearch(searchTerm,
-            page: page,
-            categories: selectedCategory,
-            isPopular: isPopular,
-            isWinner: isWinner,
-            isEditorsChoice: isEditorsChoice,
-            sortOrder: sortString);
-        if (page == 1 && result.meta != null) {
-          maxPage = (result.meta!.total / (result.meta!.pageSize)).ceil();
-        }
-
-        List<Submission> results = result.data;
-        searchResults = results;
-
-        _logger.info('page: $page');
-        _logger.info('maxPage: $maxPage');
       }
+    } else {
+      if (searchTerm.isEmpty || searchTerm.length < 3) {
+        return;
+      }
+      SearchResult result = await api.beginSearch(searchTerm,
+          page: page,
+          categories: selectedCategory,
+          isPopular: isPopular,
+          isWinner: isWinner,
+          isEditorsChoice: isEditorsChoice,
+          sortOrder: sortString);
+      if (page == 1 && result.meta != null) {
+        maxPage = (result.meta!.total / (result.meta!.pageSize)).ceil();
+      }
+
+      List<Submission> results = result.data;
+      searchResults = results;
+
+      _logger.info('page: $page');
+      _logger.info('maxPage: $maxPage');
     }
   }
 }


### PR DESCRIPTION
In search_controller.dart, the Story Search functionality was broken because of a mismatched curly bracket pair on the `} else {` section.

I moved one curly brace up and adjusted indents to make it work, no other changes needed.