### PR TITLE
save search categories in SharedPreferences

### DIFF
--- a/lib/classes/prefs_functions.dart
+++ b/lib/classes/prefs_functions.dart
@@ -34,4 +34,20 @@ class PrefsFunctions {
       scrollController.jumpTo(lastPagePosition);
     });
   }
+
+  void saveSearchCategories(List<String> categories) {
+    preferences.setStringList('searchCategories', categories);
+  }
+
+  List<String> getSearchCategories() {
+    List<String>? csvCategories = preferences.getStringList('searchCategories');
+
+    // init to no categories
+    if (csvCategories == null) {
+      preferences.setStringList('searchCategories', []);
+      return [];
+    }
+
+    return csvCategories;
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -61,6 +61,9 @@ class _MyAppState extends State<MyApp> {
       loginController.loginState = LoginState.loggedOut;
     }
     await litSearchController.getCategories();
+
+    // read saved search categories from SharedPreferences on app start
+    litSearchController.selectedCategory = prefsFunctions.getSearchCategories();
   }
 
   @override

--- a/lib/screens/widgets/lit_category_multiselect_dropdown.dart
+++ b/lib/screens/widgets/lit_category_multiselect_dropdown.dart
@@ -50,6 +50,9 @@ class _LitMultiCategoriesState extends State<LitMultiCategories> {
             widget.searchController.selectedCategory = [
               ...options.where((option) => option.id != 1).map((option) => option.id.toString())
             ];
+
+            // save search categories to SharedPreferences when selections change
+            prefsFunctions.saveSearchCategories(widget.searchController.selectedCategory);
           },
           items: categoryItems.map((category) {
             return DropdownItem<Category>(


### PR DESCRIPTION
Add a new SharedPreferences entry called "searchCategories" allowing search categories to persist across app restarts and suspends and suspends and so on.